### PR TITLE
ci(syntax): fix deprecated actions syntax. Fixes #660

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: function_state
         run: |
           state=$(aws lambda get-function --function-name ${{ secrets.LAMBDA_FUNCTION }} --query 'Configuration.State' --output text)
-          echo '::set-output name=state::'"$state"
+          echo "state=$state" >> $GITHUB_OUTPUT
 
       - name: Verify function is in active state
         if: steps.function_state.outputs.state != 'Active'
@@ -61,7 +61,7 @@ jobs:
         run: |
           set -o pipefail
           function_version=$( aws lambda publish-version --function-name ${{ secrets.LAMBDA_FUNCTION }} | jq -r ".Version" )
-          echo '::set-output name=function_version::'"$function_version"
+          echo "function_version=$function_version" >> $GITHUB_OUTPUT
 
       - name: Update alias Live with new function version
         run: >

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -47,7 +47,7 @@ jobs:
         id: function_state
         run: |
           state=$(aws lambda get-function --function-name ${{ secrets.LAMBDA_FUNCTION }} --query 'Configuration.State' --output text)
-          echo '::set-output name=state::'"$state"
+          echo "state=$state" >> $GITHUB_OUTPUT
 
       - name: Verify function is in active state
         if: steps.function_state.outputs.state != 'Active'


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
## Description
Remove usage of set-output on the Github Actions Workflows

### Describe what you did and why.
I followed the specs on the issue with the help wanted label

**Related issue (if any):** fixes #660

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
